### PR TITLE
Change of time performance in table 6

### DIFF
--- a/appendix_perf.tex
+++ b/appendix_perf.tex
@@ -66,7 +66,7 @@ Since MOC is hierarchical, its volume mainly depends on three factors:
 {\scriptsize
 \begin{tabular}{p{0.2\textwidth}p{0.2\textwidth}p{0.2\textwidth}p{0.2\textwidth}}
 \sptablerule
-\textbf{T Order} & \textbf{S order} & \textbf{Volume} & \textbf{Generation \newline time (ms)}\\
+\textbf{T Order} & \textbf{S order} & \textbf{Volume} & \textbf{Generation \newline time (s)}\\
 \sptablerule
 15&	6&	269KB&	0.3\\
 19&	8&	511KB&	0.3\\


### PR DESCRIPTION
There was a mistake in the units in Table 6, s instead of ms. This fixes that. 