### PR TITLE
Use utf-8 for author accents; switch Makefile to PR for upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ DOCNAME = moc
 DOCVERSION = 2.0
 
 # Publication date, ISO format; update manually for "releases"
-DOCDATE = 2021-10-15
+DOCDATE = 2021-11-01
 
 # What is it you're writing: NOTE, WD, PR, or REC
-DOCTYPE = WD
+DOCTYPE = PR
 
 # Source files for the TeX document (but the main file must always
 # be called $(DOCNAME).tex
@@ -26,6 +26,6 @@ VECTORFIGURES =
 AUX_FILES = 
 
 # Email to upload the document to ivoa.net/documents
-AUTHOR_EMAIL = ada.nebot@astro.unistra.fr
+AUTHOR_EMAIL = tdonaldson@stsci.edu
 
 include ivoatex/Makefile

--- a/moc.tex
+++ b/moc.tex
@@ -57,7 +57,7 @@
 \author[http://www.ivoa.net/twiki/bin/view/IVOA/MarkTaylor]{Mark Taylor (University of Bristol)}
 \author{Wil O'Mullane (Vera C. Rubin Observatory)}
 \author{Martin Reinecke (Max Plank)}
-\author{S\'{e}bastien Derri\`{e}re (CDS)}
+\author{Sébastien Derrière (CDS)}
 
 \editor[http://www.ivoa.net/twiki/bin/view/IVOA/PierreFernique]{Pierre Fernique}
 \editor[http://www.ivoa.net/twiki/bin/view/IVOA/AdaNebot]{Ada Nebot}

--- a/moc.tex
+++ b/moc.tex
@@ -56,7 +56,7 @@
 \author{Francois-Xavier Pineau (CDS)}
 \author[http://www.ivoa.net/twiki/bin/view/IVOA/MarkTaylor]{Mark Taylor (University of Bristol)}
 \author{Wil O'Mullane (Vera C. Rubin Observatory)}
-\author{Martin Reinecke (Max Plank)}
+\author{Martin Reinecke (Max Planck)}
 \author{Sébastien Derrière (CDS)}
 
 \editor[http://www.ivoa.net/twiki/bin/view/IVOA/PierreFernique]{Pierre Fernique}


### PR DESCRIPTION
While preparing the document for PR status, I realized that the accents in an author's name were not being rendered correctly in html format.  Instead of using the `inputenc` Latex package, I just typed the accented letters using utf-8 directly into `moc.html`.  This seems to work for both the pdf and html renderings.

This PR also includes the `Makefile` updates for submitting the doc as a PR.