### PR TITLE
Use listings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,13 @@ DOCTYPE = WD
 
 # Source files for the TeX document (but the main file must always
 # be called $(DOCNAME).tex
-SOURCES = $(DOCNAME).tex
+SOURCES = $(DOCNAME).tex appendix_algo.tex appendix_json.tex \
+	appendix_perf.tex table1.tex table2.tex table3.tex
 
 # List of pixel image files to be included in submitted package 
-#FIGURES = Image1.jpeg Image2.jpeg
+FIGURES = kilo.png kilo1.png kilo2.png kilo3.png kilo4.png \
+	STMOCbin.png operation.png panstarrs.png smoc_view.png stmoc_op.png \
+	stmoc_view.png tmoc_view.png
 
 # List of PDF figures (for vector graphics)
 VECTORFIGURES = 

--- a/appendix_algo.tex
+++ b/appendix_algo.tex
@@ -8,14 +8,14 @@ practice is to store range sets of continuous cells [minValue
   .. maxValue[, instead of individual cells.
 
 \subsection{Union: moc1 $\cup$ moc2}
-\begin{verbatim}
+\begin{lstlisting}
    Map moc1 to rangeList
    Map moc2 in the same rangeList
    Unmap the resulting rangeList
-\end{verbatim}
+\end{lstlisting}
 
 \subsection{Intersection: moc1 $\cap$ moc2}
-\begin{verbatim}
+\begin{lstlisting}
    Map moc1 in rangeList1
    foreach order/index of moc2
         shift=2*(maxOrder-order)
@@ -23,18 +23,18 @@ practice is to store range sets of continuous cells [minValue
               [index << shift .. index+1 << shift[
         and   the corresponding range(s) of rangeList1
    Unmap rangeList2
-\end{verbatim}
+\end{lstlisting}
 
 \subsection{Map: moc To rangeList}
-\begin{verbatim}
+\begin{lstlisting}
    foreach order/index of moc
          shift=2*(maxOrder-order)
          append in rangeList [index << shift , (index+1) << shift[
          (the range overlapping must be adjusted)
-\end{verbatim}
+\end{lstlisting}
 
 \subsection{Unmap: rangeList To moc}
-\begin{verbatim}
+\begin{lstlisting}
    for order = 0 to maxOrder
       end if rangeList is empty
       shift = 2*(maxOrder-order)
@@ -44,7 +44,7 @@ practice is to store range sets of continuous cells [minValue
                m1 = (min+offset) >> shift
                m2 = max >> shift
          remove from rangeList [m1<<shift .. m2<<shift[
-\end{verbatim}
+\end{lstlisting}
 
 \section{Basic HEALPix functions}
 For generating space MOC from observations, or drawing them on the
@@ -71,9 +71,10 @@ For generating TMOC from observations, a time library might be required to conve
 \item \url{http://javastro.github.io/jsofa/}
 \item \url{https://docs.astropy.org/en/stable/time/#module-astropy.time}
 \item Obtain the index from the JD: 
-\begin{Verbatim}
-  static public long getMicrosec(double jd, long offset) {
-      long micron = (long)(jd*DAYMICROSEC);
-      return micron + (offset*86400000000L);
-\end{Verbatim}
+\begin{lstlisting}[language=C]
+static public long getMicrosec(double jd, long offset) {
+    long micron = (long)(jd*DAYMICROSEC);
+    return micron + (offset*86400000000L);
+}
+\end{lstlisting}
 \end{itemize} 

--- a/appendix_json.tex
+++ b/appendix_json.tex
@@ -3,9 +3,9 @@ If it is required to write a MOC as an JSON string,
 it is suggested to use the following syntax:
 
 \par\noindent
-\begin{Verbatim}
-   { “order”:[index,index,...], “order”:[index, index...], ... }
-\end{Verbatim}
+\begin{lstlisting}[]
+   { "order":[index,index,...], "order":[index, index...], ... }
+\end{lstlisting}
 
 As for the ASCII MOC serialization, if the best resolution
 of the MOC (MOCORDER) is greater than the greatest stored order, the
@@ -13,38 +13,56 @@ MOCORDER should be provided with an empty index list.
 
 \paragraph{Example of a JSON SMOC or TMOC:}
 \par\noindent
-\begin{Verbatim}[frame=single]
-    {“1“:[1,2,4], “2“:[12,13,14,21,23,25], “8“:[]}
-\end{Verbatim}
+\begin{lstlisting}[]
+    {"1":[1,2,4], "2":[12,13,14,21,23,25], "8":[]}
+\end{lstlisting}
 
 As with ASCII encoding, the differentiation of a spatial MOC from a temporal MOC could be done by prefixing the JSON MOC with an 's' or a 't' using a dedicated JSON hierarchy level. In the absence of this information, the nature of the MOC is determined by its context of use.
 
-\par\noindent
-\begin{Verbatim}[frame=single, xrightmargin=-3cm] 
-     {"t": { “order”:[index,index,...], “order”:[index, index...], ... } }
-  or {"s": { “order”:[index,index,...], “order”:[index, index...], ... } }
-\end{Verbatim}
+\begin{lstlisting}[]
+{"t": {
+  "order":[index,index,...],
+  "order":[index, index...], ...
+} }
+\end{lstlisting}
+
+or
+
+\begin{lstlisting}[]
+{"s": {
+  "order":[index,index,...],
+  "order":[index, index...], ...
+} }
+\end{lstlisting}
 
 
 The coding of an STMOC will then be a list of couples (SMOC,TMOC) formalized in the following way:
-\par\noindent
-\begin{Verbatim}[frame=single, xrightmargin=-3cm] 
-     [
-        {"t": { “order”:[index,index,...], “order”:[index, index...], ... } },
-        {"s": { “order”:[index,index,...], “order”:[index, index...], ... } },
-        ...
-        {"t": { “order”:[index,index,...], “order”:[index, index...], ... } },
-        {"s": { “order”:[index,index,...], “order”:[index, index...], ... } }
-     ]
-\end{Verbatim}
 
-If the spatial or temporal orders of the last "order":[index,index,...] pair is lower than the respective spatial or temporal MOCORDER, then add an additional pair at the highest order with an empty index list.
+\begin{lstlisting}[]
+[
+   {"t": {
+    "order":[index,index,...],
+    "order":[index, index...], ... } },
+   {"s": {
+    "order":[index,index,...],
+    "order":[index, index...], ... } },
+   ...
+   {"t": {
+    "order":[index,index,...],
+    "order":[index, index...], ... } },
+   {"s": {
+    "order":[index,index,...],
+    "order":[index, index...], ... } }
+]
+\end{lstlisting}
+
+If the spatial or temporal orders of the last \verb|"order":[index,index,...]| pair is lower than the respective spatial or temporal MOCORDER, then add an additional pair at the highest order with an empty index list.
 
 \paragraph{Example of a JSON STMOC:}
 \par\noindent
-\begin{Verbatim}[frame=single]
+\begin{lstlisting}[]
    [  { "t":{ "61":[0]}, "s":{ "29":[0,1,2]},
       { "t":{ "61":[2]}, "s":{ "28":[0]} },
       { "t":{ "61":[]}, "s":{ "29":[]} ]
-\end{Verbatim}
+\end{lstlisting}
 

--- a/moc.lof
+++ b/moc.lof
@@ -1,11 +1,11 @@
-\contentsline {figure}{\numberline {1}{\ignorespaces IVOA architecture diagram}}{5}{figure.caption.1}% 
-\contentsline {figure}{\numberline {2}{\ignorespaces PanSTARRS observations and the associated spatial and temporal coverage within three different periods of time. The volume of the PanSTARRS MOC at a temporal resolution of about 17 minutes and spatial resolution of 52 arcsec is 320\,MB.\relax }}{7}{figure.caption.2}% 
-\contentsline {figure}{\numberline {3}{\ignorespaces Intersection of HST ACS observations and Saturn ephemeris Space-Time-MOC\relax }}{7}{figure.caption.3}% 
-\contentsline {figure}{\numberline {4}{\ignorespaces A mock electromagnetic follow-up campaign of a gravitational-wave sky localization over a time period (left). A schematic kilonova light-curve with the observations temporal coverage (top right) and associated spatial coverage (bottom right).\relax }}{9}{figure.caption.4}% 
-\contentsline {figure}{\numberline {5}{\ignorespaces HEALPix partition of the sphere\relax }}{12}{figure.caption.5}% 
-\contentsline {figure}{\numberline {6}{\ignorespaces SMOC: from the image to the list of numbers based on HEALPix hierarchy tessellation\relax }}{13}{figure.caption.6}% 
-\contentsline {figure}{\numberline {7}{\ignorespaces TMOC: from the time series to the list of numbers based on time discretization\relax }}{15}{figure.caption.9}% 
-\contentsline {figure}{\numberline {8}{\ignorespaces STMOC visual representation in which at at given TMOC range we obtain the corresponding SMOC\relax }}{16}{figure.caption.10}% 
-\contentsline {figure}{\numberline {9}{\ignorespaces HEALPix numbering principle\relax }}{17}{figure.caption.11}% 
-\contentsline {figure}{\numberline {10}{\ignorespaces STMOC encoding with two independent numbering system\relax }}{22}{figure.caption.14}% 
-\contentsline {figure}{\numberline {11}{\ignorespaces Visualisation of MOC operations}}{25}{figure.caption.16}% 
+\contentsline {figure}{\numberline {1}{\ignorespaces IVOA architecture diagram}}{5}{figure.caption.1}%
+\contentsline {figure}{\numberline {2}{\ignorespaces PanSTARRS observations and the associated spatial and temporal coverage within three different periods of time. The volume of the PanSTARRS MOC at a temporal resolution of about 17 minutes and spatial resolution of 52 arcsec is 320\,MB.\relax }}{7}{figure.caption.2}%
+\contentsline {figure}{\numberline {3}{\ignorespaces Intersection of HST ACS observations and Saturn ephemeris Space-Time-MOC\relax }}{7}{figure.caption.3}%
+\contentsline {figure}{\numberline {4}{\ignorespaces A mock electromagnetic follow-up campaign of a gravitational-wave sky localization over a time period (left). A schematic kilonova light-curve with the observations temporal coverage (top right) and associated spatial coverage (bottom right).\relax }}{9}{figure.caption.4}%
+\contentsline {figure}{\numberline {5}{\ignorespaces HEALPix partition of the sphere\relax }}{12}{figure.caption.5}%
+\contentsline {figure}{\numberline {6}{\ignorespaces SMOC: from the image to the list of numbers based on HEALPix hierarchy tessellation\relax }}{13}{figure.caption.6}%
+\contentsline {figure}{\numberline {7}{\ignorespaces TMOC: from the time series to the list of numbers based on time discretization\relax }}{15}{figure.caption.9}%
+\contentsline {figure}{\numberline {8}{\ignorespaces STMOC visual representation in which at at given TMOC range we obtain the corresponding SMOC\relax }}{16}{figure.caption.10}%
+\contentsline {figure}{\numberline {9}{\ignorespaces HEALPix numbering principle\relax }}{17}{figure.caption.11}%
+\contentsline {figure}{\numberline {10}{\ignorespaces STMOC encoding with two independent numbering system\relax }}{21}{figure.caption.14}%
+\contentsline {figure}{\numberline {11}{\ignorespaces Visualisation of MOC operations}}{25}{figure.caption.16}%

--- a/moc.lot
+++ b/moc.lot
@@ -1,7 +1,7 @@
-\contentsline {table}{\numberline {1}{\ignorespaces SMOC order and cell resolutions}}{13}{table.caption.7}% 
-\contentsline {table}{\numberline {2}{\ignorespaces TMOC order and cell resolutions}}{14}{table.caption.8}% 
-\contentsline {table}{\numberline {3}{\ignorespaces FITS Keywords for MOC.\relax }}{23}{table.caption.15}% 
-\contentsline {table}{\numberline {4}{\ignorespaces SMOC performances}}{30}{table.caption.17}% 
-\contentsline {table}{\numberline {5}{\ignorespaces TMOC performances}}{31}{table.caption.18}% 
-\contentsline {table}{\numberline {6}{\ignorespaces STMOC performances}}{31}{table.caption.19}% 
-\contentsline {table}{\numberline {7}{\ignorespaces STMOC operation performances}}{31}{table.caption.20}% 
+\contentsline {table}{\numberline {1}{\ignorespaces SMOC order and cell resolutions}}{13}{table.caption.7}%
+\contentsline {table}{\numberline {2}{\ignorespaces TMOC order and cell resolutions}}{14}{table.caption.8}%
+\contentsline {table}{\numberline {3}{\ignorespaces FITS Keywords for MOC.\relax }}{23}{table.caption.15}%
+\contentsline {table}{\numberline {4}{\ignorespaces SMOC performances}}{30}{table.caption.17}%
+\contentsline {table}{\numberline {5}{\ignorespaces TMOC performances}}{30}{table.caption.18}%
+\contentsline {table}{\numberline {6}{\ignorespaces STMOC performances}}{31}{table.caption.19}%
+\contentsline {table}{\numberline {7}{\ignorespaces STMOC operation performances}}{31}{table.caption.20}%

--- a/moc.tex
+++ b/moc.tex
@@ -7,9 +7,9 @@
 \usepackage[normalem]{ulem}
 \usepackage{fancyvrb}
 \usepackage{appendix}
-\lstloadlanguages{sh,make,[latex]tex}
+\lstloadlanguages{C}
 \lstset{flexiblecolumns=true,numberstyle=\small,showstringspaces=False,
-  identifierstyle=\texttt,defaultdialect=[latex]tex,language=tex}
+  basicstyle=\ttfamily,defaultdialect=[latex]tex,language=tex}
 
 \usepackage[colorinlistoftodos]{todonotes}
 
@@ -668,9 +668,9 @@ pair (order, cell), and the assumed best resolution would be at order 2.
 
 
 \paragraph{Example of an ASCII MOC:}
-\begin{Verbatim}[frame=single]
+\begin{lstlisting}[]
     1/1 2 4 2/12-14 21 23 25 8/
-\end{Verbatim}
+\end{lstlisting}
 
 \begin{table}[!htbp]
 \begin{center}
@@ -688,15 +688,15 @@ Cell:      & 1    & 2 & 4 & 12 to 14 & 21 & 23 & 25 & \\
 
 
 \paragraph{EBNF definition of an ASCII MOC:}
-\begin{Verbatim}[frame=single]
+\begin{lstlisting}[]
   moc ::= ordval (sep+ ordval)* [sep+ order]
   ordval ::= order sep* vals
-  order ::= int ’/’
+  order ::= int '/'
   vals ::= val (sep+ val)*
-  val ::= int? | (int ’-’ int)
+  val ::= int? | (int '-' int)
   sep ::= [ \n\r]
   int ::= [0-9]+
-\end{Verbatim}
+\end{lstlisting}
 
 
 If the context does not allow to distinguish a TMOC to a SMOC,
@@ -719,9 +719,9 @@ The character is thus omitted until the next dimension element is
 defined.
 
 \paragraph{Example of an ASCII STMOC:}
-\begin{Verbatim}[frame=single]
+\begin{lstlisting}[]
   t61/1 s29/0-2 t61/3 s28/0 t60/2 61/6 s29/2 5
-\end{Verbatim}
+\end{lstlisting}
 
 \begin{table}[!htbp]
 \begin{center}
@@ -759,9 +759,9 @@ dimensions is always time first.
 \par\noindent
 This list of ranges will be  coded in in a list of 64bits integers
 (time indices with the 64th bit forced to 1) as:
-\begin{verbatim}
+\begin{lstlisting}[]
    tmin1 tmax2 smin1 smax1 tmin2 tmax2 tmin3 tmax3 smin2 smax2 smin3 smax3
-\end{verbatim}
+\end{lstlisting}
 
 STMOC encoding must conform to the following simple rules:
 \begin{itemize}
@@ -789,7 +789,7 @@ Other FITS Keywords could be used to augment the information like DATES and ORIG
 %\clearpage 
 \paragraph{Example of FITS headers for a MOC:}
 \par\noindent
-\begin{Verbatim}[frame=single, fontsize=\small]
+\begin{lstlisting}[basicstyle=\footnotesize\ttfamily]
 SIMPLE   =                      T
 BITPIX   =                      8
 NAXIS    =                      0
@@ -818,7 +818,7 @@ ORIGIN   = 'ivo://CDS'           / MOC origin
 DATE     = '2013-06-15T11:50:43' / MOC creation date
 EXTNAME  = 'Tycho MOC'           / MOC name
 END
-\end{Verbatim}
+\end{lstlisting}
 
 \section{MOC usage constraints}
 

--- a/moc.tex
+++ b/moc.tex
@@ -1,4 +1,4 @@
-\documentclass[11pt,a4paper]{ivoa}
+\documentclass[11pt,a4paper]{ivoa} 
 \input tthdefs
 
 \usepackage{makecell}
@@ -606,16 +606,16 @@ order are stored following the RANGE packaging.
 \paragraph{NUNIQ Packaging}
 The NUNIQ scheme defines an algorithm for packaging a MOC pair (order,
 index) into a single integer for compactness:
-\begin{Verbatim}[frame=single]
-    uniq = 4 * (4^order) + index
-\end{Verbatim}
+$$
+    \textit{uniq} = 4 \cdot (4\,^\textit{order}) + \textit{index}
+$$
 
 \par\noindent
 The inverse operation is:
-\begin{Verbatim}[frame=single]
-    order = log2(uniq/4) /2
-    index = uniq – 4 * (4^order)
-\end{Verbatim}
+\begin{eqnarray*}
+    \textit{order} & = &\log_2(\textit{uniq}/4)/2\\
+    \textit{index} & = &\textit{uniq} - 4 \cdot (4\,^\textit{order})
+\end{eqnarray*}
 
 \par\noindent The list of cells {\bf must} be well-formed allowing
 to express both hierarchy or range representation. The resulting


### PR DESCRIPTION
This PR moves the Verbatim environments to either proper math or lstlistings; this makes them work in HTML.

By the way, diffs are helped if you keep source lines to shorter than 80 characters (but I'll not spoil this PR...)