### PR TITLE
modify table:label content and position to build HTML

### DIFF
--- a/appendix_perf.tex
+++ b/appendix_perf.tex
@@ -30,8 +30,8 @@ Since MOC is hierarchical, its volume mainly depends on three factors:
   obtained from CADC's OBSCORE using field central position and
   not the original footprint.}
 \normalsize
-}
 \label{table:smocsizeacs}
+}
 \end{center}
 \end{table}
 
@@ -55,8 +55,8 @@ Since MOC is hierarchical, its volume mainly depends on three factors:
 \end{tabular}
 \caption[TMOC performances]{TMOCs for HST ACS science observations obtained from CADC's OBSCORE using field central position and not the original footprint.}
 \normalsize
-}
 \label{table:tmocsizeacs}
+}
 \end{center}
 \end{table}
 
@@ -82,8 +82,8 @@ Since MOC is hierarchical, its volume mainly depends on three factors:
 \end{tabular}
 \caption[STMOC performances]{STMOCs for HST ACS science observations obtained from CADC's OBSCORE using field central position and not the original footprint.}
 \normalsize
+\label{table:stmocsizeacs}
 }
-\label{table:tmocsizeacs}
 \end{center}
 \end{table}
 
@@ -104,7 +104,7 @@ STMOC 12,27&	6ms&	4ms \\
 \end{tabular}
 \caption[STMOC operation performances]{STMOCs operations between HST ACS (211453 observations) and HST WFC3 (276175 observations) science observations obtained from CADC's OBSCORE using field central position and not the original footprint.}
 \normalsize
+\label{table:stmocopsacs}
 }
-\label{table:tmocsizeacs}
 \end{center}
 \end{table}


### PR DESCRIPTION
Fix two problems with the table label tags in appendix_perf.tex:
the same string "tmocsizeacs" was used for several tables,
and the \label macros were placed in the wrong scope.
Both of these prevented the moc.html file from being built correctly.

The moc.html target now executes without error, though there are
still issues with table numbering in the HTML output.